### PR TITLE
feat: v2에 v1 핵심 기능 마이그레이션

### DIFF
--- a/hana_studio_v2.py
+++ b/hana_studio_v2.py
@@ -275,63 +275,88 @@ def run_loading_sequence(app, loading, status, progress):
 
 def main():
     """메인 함수"""
-    import atexit
+    try:
+        import atexit
 
-    # 단일 인스턴스 확인
-    if not check_single_instance():
-        print("[EXIT] 이미 실행 중인 Hana Studio v2가 있습니다.")
-        sys.exit(0)
+        print("[START] Hana Studio v2 시작...")
 
-    # 종료 시 정리 등록
-    atexit.register(cleanup_on_exit)
+        # 단일 인스턴스 확인
+        if not check_single_instance():
+            print("[EXIT] 이미 실행 중인 Hana Studio v2가 있습니다.")
+            sys.exit(0)
 
-    # High DPI 설정 (QApplication 생성 전에 환경변수 설정)
-    os.environ["QT_ENABLE_HIGHDPI_SCALING"] = "0"
-    os.environ["QT_SCALE_FACTOR_ROUNDING_POLICY"] = "Floor"
+        # 종료 시 정리 등록
+        atexit.register(cleanup_on_exit)
 
-    # Qt import
-    from PySide6.QtWidgets import QApplication
+        # High DPI 설정 (QApplication 생성 전에 환경변수 설정)
+        os.environ["QT_ENABLE_HIGHDPI_SCALING"] = "0"
+        os.environ["QT_SCALE_FACTOR_ROUNDING_POLICY"] = "Floor"
 
-    # Qt 애플리케이션 생성
-    app = QApplication(sys.argv)
+        # Qt import
+        from PySide6.QtWidgets import QApplication
 
-    # 애플리케이션 정보
-    app.setOrganizationName("Hana Studio")
-    app.setApplicationName("Hana Studio v2")
-    app.setApplicationVersion("2.0.0-MVP")
+        # Qt 애플리케이션 생성
+        app = QApplication(sys.argv)
 
-    print("=" * 60)
-    print(" Hana Studio v2 - RTAI 카드 디자인 툴")
-    print("=" * 60)
+        # 애플리케이션 정보
+        app.setOrganizationName("Hana Studio")
+        app.setApplicationName("Hana Studio v2")
+        app.setApplicationVersion("2.0.0-MVP")
 
-    # 라이선스 인증 (로딩 화면 전에)
-    from licensing.dialog import check_license
-    if not check_license():
-        print("[EXIT] 라이선스 인증 실패")
-        sys.exit(0)
+        print("=" * 60)
+        print(" Hana Studio v2 - RTAI 카드 디자인 툴")
+        print("=" * 60)
 
-    print("[OK] 라이선스 인증 완료")
+        # 라이선스 인증 (로딩 화면 전에)
+        from licensing.dialog import check_license
+        if not check_license():
+            print("[EXIT] 라이선스 인증 실패")
+            sys.exit(0)
 
-    # 로딩 화면 표시
-    loading, status, progress = create_loading_screen(app)
-    loading.show()
-    app.processEvents()
+        print("[OK] 라이선스 인증 완료")
 
-    # 단계별 로딩
-    run_loading_sequence(app, loading, status, progress)
+        # 로딩 화면 표시
+        loading, status, progress = create_loading_screen(app)
+        loading.show()
+        app.processEvents()
 
-    # 메인 윈도우 생성
-    from ui_v2 import HanaStudioMainWindowV2
-    window = HanaStudioMainWindowV2()
+        # 단계별 로딩
+        run_loading_sequence(app, loading, status, progress)
 
-    # 로딩 화면 닫고 메인 윈도우 표시
-    loading.close()
-    window.show()
+        # 메인 윈도우 생성
+        from ui_v2 import HanaStudioMainWindowV2
+        window = HanaStudioMainWindowV2()
 
-    print("[OK] Hana Studio v2 시작 완료")
+        # 로딩 화면 닫고 메인 윈도우 표시
+        loading.close()
+        window.show()
 
-    # 이벤트 루프 실행
-    sys.exit(app.exec())
+        print("[OK] Hana Studio v2 시작 완료")
+
+        # 이벤트 루프 실행
+        exit_code = app.exec()
+        print(f"[EXIT] Hana Studio v2 종료 (코드: {exit_code})")
+        sys.exit(exit_code)
+
+    except Exception as e:
+        print(f"[ERROR] 시작 오류: {e}")
+        import traceback
+        traceback.print_exc()
+
+        # 사용자 친화적 에러 다이얼로그 (Qt가 초기화된 경우)
+        try:
+            from PySide6.QtWidgets import QMessageBox, QApplication
+            if QApplication.instance():
+                QMessageBox.critical(
+                    None,
+                    "Hana Studio v2 오류",
+                    f"프로그램 시작 중 오류가 발생했습니다.\n\n{e}\n\n"
+                    "자세한 내용은 hana_studio_v2_debug.log를 확인해주세요."
+                )
+        except:
+            pass
+
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/hana_studio_v2.py
+++ b/hana_studio_v2.py
@@ -13,6 +13,41 @@ import os
 import tempfile
 from pathlib import Path
 
+
+# ============================================================
+# 안전한 로깅 시스템 (PyInstaller --windowed 모드 대응)
+# ============================================================
+
+def _setup_safe_logging():
+    """
+    PyInstaller --windowed 모드에서 안전한 로깅 설정
+
+    문제: --windowed 옵션으로 빌드하면 콘솔이 없어서
+          sys.stdout/stderr가 None이 됨 → print() 크래시
+
+    해결: 파일로 리다이렉트하여 디버깅 가능하게 유지
+    """
+    if sys.stdout is None or sys.stderr is None:
+        log_path = os.path.join(os.getcwd(), "hana_studio_v2_debug.log")
+        try:
+            log_file = open(log_path, "w", encoding="utf-8", buffering=1)
+            if sys.stdout is None:
+                sys.stdout = log_file
+            if sys.stderr is None:
+                sys.stderr = log_file
+        except Exception:
+            # 파일 생성 실패 시 devnull로 폴백
+            devnull = open(os.devnull, 'w', encoding='utf-8')
+            if sys.stdout is None:
+                sys.stdout = devnull
+            if sys.stderr is None:
+                sys.stderr = devnull
+
+
+# 모듈 로드 시 즉시 실행
+_setup_safe_logging()
+
+
 # 프로젝트 루트를 path에 추가
 sys.path.insert(0, str(Path(__file__).parent))
 

--- a/hana_studio_v2.py
+++ b/hana_studio_v2.py
@@ -146,6 +146,98 @@ def cleanup_on_exit():
             pass
 
 
+def create_loading_screen(app):
+    """로딩 화면 생성"""
+    from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QProgressBar
+    from PySide6.QtCore import Qt
+    from PySide6.QtGui import QFont
+
+    loading = QWidget()
+    loading.setWindowTitle("Hana Studio v2")
+    loading.setFixedSize(360, 160)
+    loading.setWindowFlags(Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnTopHint)
+    loading.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, False)
+    loading.setStyleSheet("""
+        QWidget {
+            background-color: #1a1a2e;
+            border-radius: 12px;
+        }
+    """)
+
+    layout = QVBoxLayout(loading)
+    layout.setContentsMargins(32, 28, 32, 28)
+    layout.setSpacing(16)
+
+    # 타이틀
+    title = QLabel("Hana Studio v2")
+    title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+    title.setFont(QFont("Segoe UI", 18, QFont.Weight.DemiBold))
+    title.setStyleSheet("color: #eef1ff; background: transparent;")
+    layout.addWidget(title)
+
+    # 상태 텍스트
+    status = QLabel("시작하는 중...")
+    status.setAlignment(Qt.AlignmentFlag.AlignCenter)
+    status.setFont(QFont("Segoe UI", 10))
+    status.setStyleSheet("color: #a0a0b0; background: transparent;")
+    layout.addWidget(status)
+
+    # 프로그레스 바
+    progress = QProgressBar()
+    progress.setFixedHeight(4)
+    progress.setTextVisible(False)
+    progress.setRange(0, 100)
+    progress.setValue(0)
+    progress.setStyleSheet("""
+        QProgressBar {
+            background-color: #2a2a4e;
+            border: none;
+            border-radius: 2px;
+        }
+        QProgressBar::chunk {
+            background-color: #6c63ff;
+            border-radius: 2px;
+        }
+    """)
+    layout.addWidget(progress)
+
+    # 화면 중앙 배치
+    screen = app.primaryScreen().geometry()
+    x = (screen.width() - loading.width()) // 2
+    y = (screen.height() - loading.height()) // 2
+    loading.move(x, y)
+
+    return loading, status, progress
+
+
+def run_loading_sequence(app, loading, status, progress):
+    """단계별 로딩 실행"""
+    steps = [
+        ("NumPy 로딩...", 15, lambda: __import__('numpy')),
+        ("OpenCV 로딩...", 35, lambda: __import__('cv2')),
+        ("ONNX Runtime 로딩...", 55, lambda: __import__('onnxruntime')),
+        ("UI 모듈 로딩...", 75, lambda: __import__('ui_v2')),
+        ("메인 윈도우 준비...", 90, None),
+    ]
+
+    for msg, prog, loader in steps:
+        status.setText(msg)
+        progress.setValue(prog)
+        app.processEvents()
+
+        if loader:
+            try:
+                loader()
+                print(f"[OK] {msg.replace('...', '')}")
+            except Exception as e:
+                print(f"[WARN] {msg} 실패: {e}")
+
+        app.processEvents()
+
+    progress.setValue(100)
+    app.processEvents()
+
+
 def main():
     """메인 함수"""
     import atexit
@@ -179,24 +271,8 @@ def main():
     print("=" * 60)
     print(" Hana Studio v2 - RTAI 카드 디자인 툴")
     print("=" * 60)
-    print()
-    print("MVP 기능:")
-    print("  ✅ RTAI 규격 캔버스 (600 DPI)")
-    print("  ✅ 이미지 레이어 (드래그, 크기 조절, 회전)")
-    print("  ✅ 텍스트 레이어 (폰트, 색상, 크기)")
-    print("  ✅ Canva 스타일 UI")
-    print("  ✅ 줌/팬 기능")
-    print()
-    print("다음 단계:")
-    print("  ⬜ 600DPI 인쇄 렌더링")
-    print("  ⬜ 프린터 모듈 통합")
-    print("  ⬜ AI 배경제거 통합")
-    print("  ⬜ 템플릿/프리셋 시스템")
-    print()
-    print("=" * 60)
-    print()
 
-    # 라이선스 인증
+    # 라이선스 인증 (로딩 화면 전에)
     from licensing.dialog import check_license
     if not check_license():
         print("[EXIT] 라이선스 인증 실패")
@@ -204,10 +280,23 @@ def main():
 
     print("[OK] 라이선스 인증 완료")
 
-    # 메인 윈도우 생성 및 표시
+    # 로딩 화면 표시
+    loading, status, progress = create_loading_screen(app)
+    loading.show()
+    app.processEvents()
+
+    # 단계별 로딩
+    run_loading_sequence(app, loading, status, progress)
+
+    # 메인 윈도우 생성
     from ui_v2 import HanaStudioMainWindowV2
     window = HanaStudioMainWindowV2()
+
+    # 로딩 화면 닫고 메인 윈도우 표시
+    loading.close()
     window.show()
+
+    print("[OK] Hana Studio v2 시작 완료")
 
     # 이벤트 루프 실행
     sys.exit(app.exec())

--- a/hana_studio_v2.py
+++ b/hana_studio_v2.py
@@ -9,19 +9,159 @@ MVP (Minimum Viable Product)
 """
 
 import sys
+import os
+import tempfile
 from pathlib import Path
-
-from PySide6.QtWidgets import QApplication
-from PySide6.QtCore import Qt
 
 # 프로젝트 루트를 path에 추가
 sys.path.insert(0, str(Path(__file__).parent))
 
-from ui_v2 import HanaStudioMainWindowV2
+# 앱 고유 식별자
+APP_MUTEX_NAME = "HanaStudioV2_SingleInstance_Mutex"
+APP_LOCK_FILE = os.path.join(tempfile.gettempdir(), "hana_studio_v2.lock")
+
+# Mutex 핸들 (전역으로 유지해야 함)
+_mutex_handle = None
+
+
+def check_single_instance() -> bool:
+    """
+    단일 인스턴스 실행 확인 (Named Mutex + Lock 파일 하이브리드)
+
+    Returns:
+        True: 첫 번째 인스턴스 (실행 가능)
+        False: 이미 실행 중인 인스턴스 존재
+    """
+    global _mutex_handle
+
+    if sys.platform == "win32":
+        # Windows: Named Mutex 사용 (가장 안정적)
+        try:
+            import ctypes
+            from ctypes import wintypes
+
+            kernel32 = ctypes.windll.kernel32
+
+            # CreateMutexW 호출
+            _mutex_handle = kernel32.CreateMutexW(
+                None,  # 기본 보안 속성
+                True,  # 초기 소유권 요청
+                APP_MUTEX_NAME  # Mutex 이름
+            )
+
+            # ERROR_ALREADY_EXISTS (183) 확인
+            last_error = kernel32.GetLastError()
+            if last_error == 183:  # ERROR_ALREADY_EXISTS
+                # 이미 실행 중 - 하지만 좀비인지 확인
+                if _is_zombie_process():
+                    # 좀비면 강제로 뮤텍스 해제하고 재시도
+                    kernel32.CloseHandle(_mutex_handle)
+                    _cleanup_lock_file()
+                    _mutex_handle = kernel32.CreateMutexW(None, True, APP_MUTEX_NAME)
+                    if kernel32.GetLastError() == 183:
+                        return False
+                else:
+                    return False
+
+            # Lock 파일에 현재 PID 저장
+            _write_lock_file()
+            return True
+
+        except Exception as e:
+            print(f"[WARN] Mutex 생성 실패, Lock 파일 방식 사용: {e}")
+            return _check_lock_file()
+    else:
+        # Linux/Mac: Lock 파일 방식
+        return _check_lock_file()
+
+
+def _is_zombie_process() -> bool:
+    """Lock 파일의 PID가 좀비(존재하지 않는 프로세스)인지 확인"""
+    try:
+        if not os.path.exists(APP_LOCK_FILE):
+            return True
+
+        with open(APP_LOCK_FILE, 'r') as f:
+            old_pid = int(f.read().strip())
+
+        # 해당 PID가 실제로 존재하는지 확인
+        if sys.platform == "win32":
+            import ctypes
+            kernel32 = ctypes.windll.kernel32
+            PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+            handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, old_pid)
+            if handle:
+                kernel32.CloseHandle(handle)
+                return False  # 프로세스 존재
+            return True  # 프로세스 없음 (좀비)
+        else:
+            os.kill(old_pid, 0)  # 시그널 0으로 존재 확인
+            return False
+    except (ValueError, FileNotFoundError, OSError, ProcessLookupError):
+        return True
+
+
+def _write_lock_file():
+    """현재 PID를 Lock 파일에 저장"""
+    try:
+        with open(APP_LOCK_FILE, 'w') as f:
+            f.write(str(os.getpid()))
+    except Exception:
+        pass
+
+
+def _cleanup_lock_file():
+    """Lock 파일 삭제"""
+    try:
+        if os.path.exists(APP_LOCK_FILE):
+            os.remove(APP_LOCK_FILE)
+    except Exception:
+        pass
+
+
+def _check_lock_file() -> bool:
+    """Lock 파일 기반 단일 인스턴스 확인 (폴백)"""
+    if _is_zombie_process():
+        _cleanup_lock_file()
+
+    if os.path.exists(APP_LOCK_FILE):
+        return False
+
+    _write_lock_file()
+    return True
+
+
+def cleanup_on_exit():
+    """종료 시 리소스 정리"""
+    global _mutex_handle
+
+    _cleanup_lock_file()
+
+    if _mutex_handle and sys.platform == "win32":
+        try:
+            import ctypes
+            ctypes.windll.kernel32.ReleaseMutex(_mutex_handle)
+            ctypes.windll.kernel32.CloseHandle(_mutex_handle)
+        except Exception:
+            pass
 
 
 def main():
     """메인 함수"""
+    import atexit
+
+    # 단일 인스턴스 확인
+    if not check_single_instance():
+        print("[EXIT] 이미 실행 중인 Hana Studio v2가 있습니다.")
+        sys.exit(0)
+
+    # 종료 시 정리 등록
+    atexit.register(cleanup_on_exit)
+
+    # Qt import (단일 인스턴스 확인 후)
+    from PySide6.QtWidgets import QApplication
+    from PySide6.QtCore import Qt
+
     # Qt 애플리케이션 생성
     app = QApplication(sys.argv)
 
@@ -65,6 +205,7 @@ def main():
     print("[OK] 라이선스 인증 완료")
 
     # 메인 윈도우 생성 및 표시
+    from ui_v2 import HanaStudioMainWindowV2
     window = HanaStudioMainWindowV2()
     window.show()
 

--- a/hana_studio_v2.py
+++ b/hana_studio_v2.py
@@ -285,18 +285,15 @@ def main():
     # 종료 시 정리 등록
     atexit.register(cleanup_on_exit)
 
-    # Qt import (단일 인스턴스 확인 후)
+    # High DPI 설정 (QApplication 생성 전에 환경변수 설정)
+    os.environ["QT_ENABLE_HIGHDPI_SCALING"] = "0"
+    os.environ["QT_SCALE_FACTOR_ROUNDING_POLICY"] = "Floor"
+
+    # Qt import
     from PySide6.QtWidgets import QApplication
-    from PySide6.QtCore import Qt
 
     # Qt 애플리케이션 생성
     app = QApplication(sys.argv)
-
-    # 고해상도 디스플레이 지원
-    app.setAttribute(Qt.ApplicationAttribute.AA_UseHighDpiPixmaps, True)
-    QApplication.setHighDpiScaleFactorRoundingPolicy(
-        Qt.HighDpiScaleFactorRoundingPolicy.PassThrough
-    )
 
     # 애플리케이션 정보
     app.setOrganizationName("Hana Studio")

--- a/hana_studio_v2.py
+++ b/hana_studio_v2.py
@@ -56,6 +56,14 @@ def main():
     print("=" * 60)
     print()
 
+    # 라이선스 인증
+    from licensing.dialog import check_license
+    if not check_license():
+        print("[EXIT] 라이선스 인증 실패")
+        sys.exit(0)
+
+    print("[OK] 라이선스 인증 완료")
+
     # 메인 윈도우 생성 및 표시
     window = HanaStudioMainWindowV2()
     window.show()

--- a/ui_v2/main_window.py
+++ b/ui_v2/main_window.py
@@ -1448,3 +1448,11 @@ class HanaStudioMainWindowV2(QMainWindow):
             print(f"[ERROR] 프린터 선택 대화상자 실패: {e}")
             import traceback
             traceback.print_exc()
+
+    def closeEvent(self, event):
+        """종료 시 시그널 정리 (C++ 객체 삭제 에러 방지)"""
+        try:
+            self.canvas.scene.blockSignals(True)
+        except:
+            pass
+        event.accept()


### PR DESCRIPTION

  ## Summary
  v1에서 검증된 핵심 기능들을 v2에 마이그레이션하여 프로덕션 빌드 준비

  ## Changes

  ### 1. 라이선스 인증 모듈 연동
  - licensing.dialog.check_license() 호출 추가
  - 인증 실패 시 앱 종료 처리

  ### 2. 단일 인스턴스 실행 제한
  - Named Mutex + Lock 파일 하이브리드 방식으로 중복 실행 방지
  - Windows Named Mutex로 원자적 처리
  - Lock 파일에 PID 저장하여 좀비 프로세스 자동 감지/복구
  - atexit로 종료 시 자동 정리
  - 외부 의존성 없음 (ctypes 내장 모듈 사용)

  ### 3. 로딩 화면 추가
  - 단계별 모듈 로딩으로 UI 응답성 유지
  - NumPy, OpenCV, ONNX Runtime 순차 import
  - 다크 테마 프레임리스 로딩 팝업
  - 프로그레스 바로 로딩 진행률 표시
  - 각 단계에서 processEvents() 호출

  ### 4. 안전한 로깅 시스템
  - PyInstaller --windowed 모드에서 stdout/stderr가 None일 때 대응
  - hana_studio_v2_debug.log 파일로 리다이렉트
  - 파일 생성 실패 시 devnull로 폴백
  - print() 크래시 방지

  ### 5. High DPI 설정 통일
  - 환경변수 방식으로 변경하여 600DPI 정밀 렌더링 보장
  - QT_ENABLE_HIGHDPI_SCALING=0 (스케일링 비활성화)
  - QT_SCALE_FACTOR_ROUNDING_POLICY=Floor
  - AA_UseHighDpiPixmaps 제거 (Qt6에서 deprecated)

  ### 6. 에러 핸들링 강화
  - main() 전체를 try/except로 래핑하여 안정성 향상
  - 예외 발생 시 traceback을 로그 파일에 기록
  - 사용자 친화적 에러 다이얼로그 표시
  - 로그 파일 경로 안내 포함

  ### 7. 종료 시 RuntimeError 수정
  - closeEvent에서 scene.blockSignals(True) 호출
  - 종료 시 C++ 객체 삭제로 인한 시그널 핸들러 에러 방지