### PR TITLE
fix: 이미지/텍스트 레이어 리사이즈 핸들 개선

### DIFF
--- a/canvas/layers/base_layer.py
+++ b/canvas/layers/base_layer.py
@@ -19,13 +19,42 @@ class ResizeHandle(QGraphicsEllipseItem):
     """크기 조절 핸들"""
 
     def __init__(self, position, parent=None):
-        super().__init__(-4, -4, 8, 8, parent)
+        super().__init__(-4, -4, 8, 8, parent)  # 시각적 크기: 8x8px
         self.position = position  # 'tl', 'tr', 'bl', 'br' 등
         self.setBrush(QBrush(QColor("#4A90E2")))
         self.setPen(QPen(QColor("#FFFFFF"), 2))
         self.setZValue(1000)
         self.setCursor(self._get_cursor())
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, False)
+        self.setAcceptedMouseButtons(Qt.MouseButton.LeftButton)
+
+    def shape(self):
+        """클릭 판정 영역 확장"""
+        from PySide6.QtGui import QPainterPath
+        path = QPainterPath()
+        path.addEllipse(-10, -10, 20, 20)  # 클릭 판정: 20x20px
+        return path
+
+    def mousePressEvent(self, event):
+        """핸들 클릭 시 부모에게 리사이즈 시작 알림"""
+        parent = self.parentItem()
+        if parent and hasattr(parent, '_start_resize_from_handle'):
+            parent._start_resize_from_handle(self.position, event)
+        event.accept()
+
+    def mouseMoveEvent(self, event):
+        """드래그 시 부모에게 전달"""
+        parent = self.parentItem()
+        if parent and hasattr(parent, '_handle_resize_from_handle'):
+            parent._handle_resize_from_handle(event)
+        event.accept()
+
+    def mouseReleaseEvent(self, event):
+        """릴리즈 시 부모에게 전달"""
+        parent = self.parentItem()
+        if parent and hasattr(parent, '_end_resize_from_handle'):
+            parent._end_resize_from_handle(event)
+        event.accept()
 
     def _get_cursor(self):
         """위치에 따른 커서 설정"""
@@ -56,12 +85,41 @@ class RotateHandle(QGraphicsEllipseItem):
     """회전 핸들"""
 
     def __init__(self, parent=None):
-        super().__init__(-5, -5, 10, 10, parent)
+        super().__init__(-5, -5, 10, 10, parent)  # 시각적 크기: 10x10px
         self.setBrush(QBrush(QColor("#28A745")))
         self.setPen(QPen(QColor("#FFFFFF"), 2))
         self.setZValue(1000)
         self.setCursor(Qt.CursorShape.CrossCursor)
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, False)
+        self.setAcceptedMouseButtons(Qt.MouseButton.LeftButton)
+
+    def shape(self):
+        """클릭 판정 영역 확장"""
+        from PySide6.QtGui import QPainterPath
+        path = QPainterPath()
+        path.addEllipse(-10, -10, 20, 20)  # 클릭 판정: 20x20px
+        return path
+
+    def mousePressEvent(self, event):
+        """핸들 클릭 시 부모에게 회전 시작 알림"""
+        parent = self.parentItem()
+        if parent and hasattr(parent, '_start_rotate_from_handle'):
+            parent._start_rotate_from_handle(event)
+        event.accept()
+
+    def mouseMoveEvent(self, event):
+        """드래그 시 부모에게 전달"""
+        parent = self.parentItem()
+        if parent and hasattr(parent, '_handle_rotate_from_handle'):
+            parent._handle_rotate_from_handle(event)
+        event.accept()
+
+    def mouseReleaseEvent(self, event):
+        """릴리즈 시 부모에게 전달"""
+        parent = self.parentItem()
+        if parent and hasattr(parent, '_end_rotate_from_handle'):
+            parent._end_rotate_from_handle(event)
+        event.accept()
 
     def paint(self, painter, option, widget):
         """핸들 그리기 - 인쇄 모드에서는 렌더링하지 않음"""
@@ -246,6 +304,62 @@ class BaseLayer(QGraphicsItem):
 
         self.setRotation(self.rotation() + delta_angle)
         self.rotate_start_angle = current_angle
+
+    # ============================================================
+    # 핸들에서 직접 호출하는 메서드들 (이미지 밖에서도 동작)
+    # ============================================================
+
+    def _start_resize_from_handle(self, position, event):
+        """핸들에서 리사이즈 시작"""
+        if self.layer_locked:
+            return
+        self.is_resizing = True
+        self.resize_handle_active = position
+        self.resize_start_rect = self.boundingRect()
+        # 핸들의 로컬 좌표를 부모(레이어) 좌표로 변환
+        self.resize_start_pos = self.resize_handles[position].mapToParent(event.pos())
+
+    def _handle_resize_from_handle(self, event):
+        """핸들에서 리사이즈 처리"""
+        if not self.is_resizing:
+            return
+        # 핸들의 로컬 좌표를 부모(레이어) 좌표로 변환
+        handle = self.resize_handles.get(self.resize_handle_active)
+        if handle:
+            pos = handle.mapToParent(event.pos())
+            self._handle_resize(pos)
+
+    def _end_resize_from_handle(self, event):
+        """핸들에서 리사이즈 종료"""
+        if self.is_resizing:
+            self.is_resizing = False
+            self.resize_handle_active = None
+            self._cleanup_resize()
+            self.signals.transform_changed.emit()
+
+    def _start_rotate_from_handle(self, event):
+        """핸들에서 회전 시작"""
+        if self.layer_locked:
+            return
+        self.is_rotating = True
+        center = self.boundingRect().center()
+        # 핸들의 로컬 좌표를 부모(레이어) 좌표로 변환
+        pos = self.rotate_handle.mapToParent(event.pos())
+        self.rotate_start_angle = self._calculate_angle(center, pos)
+
+    def _handle_rotate_from_handle(self, event):
+        """핸들에서 회전 처리"""
+        if not self.is_rotating:
+            return
+        # 핸들의 로컬 좌표를 부모(레이어) 좌표로 변환
+        pos = self.rotate_handle.mapToParent(event.pos())
+        self._handle_rotation(pos)
+
+    def _end_rotate_from_handle(self, event):
+        """핸들에서 회전 종료"""
+        if self.is_rotating:
+            self.is_rotating = False
+            self.signals.transform_changed.emit()
 
     def _handle_resize(self, pos):
         """크기 조절 처리 - 서브클래스에서 구현"""

--- a/canvas/layers/base_layer.py
+++ b/canvas/layers/base_layer.py
@@ -21,6 +21,7 @@ class ResizeHandle(QGraphicsEllipseItem):
     def __init__(self, position, parent=None):
         super().__init__(-4, -4, 8, 8, parent)  # 시각적 크기: 8x8px
         self.position = position  # 'tl', 'tr', 'bl', 'br' 등
+        self._is_dragging = False
         self.setBrush(QBrush(QColor("#4A90E2")))
         self.setPen(QPen(QColor("#FFFFFF"), 2))
         self.setZValue(1000)
@@ -37,6 +38,8 @@ class ResizeHandle(QGraphicsEllipseItem):
 
     def mousePressEvent(self, event):
         """핸들 클릭 시 부모에게 리사이즈 시작 알림"""
+        self._is_dragging = True
+        self.grabMouse()  # 마우스 캡처 - 다른 아이템이 간섭 못함
         parent = self.parentItem()
         if parent and hasattr(parent, '_start_resize_from_handle'):
             parent._start_resize_from_handle(self.position, event)
@@ -44,6 +47,8 @@ class ResizeHandle(QGraphicsEllipseItem):
 
     def mouseMoveEvent(self, event):
         """드래그 시 부모에게 전달"""
+        if not self._is_dragging:
+            return
         parent = self.parentItem()
         if parent and hasattr(parent, '_handle_resize_from_handle'):
             parent._handle_resize_from_handle(event)
@@ -51,6 +56,8 @@ class ResizeHandle(QGraphicsEllipseItem):
 
     def mouseReleaseEvent(self, event):
         """릴리즈 시 부모에게 전달"""
+        self._is_dragging = False
+        self.ungrabMouse()  # 마우스 릴리즈
         parent = self.parentItem()
         if parent and hasattr(parent, '_end_resize_from_handle'):
             parent._end_resize_from_handle(event)
@@ -86,6 +93,7 @@ class RotateHandle(QGraphicsEllipseItem):
 
     def __init__(self, parent=None):
         super().__init__(-5, -5, 10, 10, parent)  # 시각적 크기: 10x10px
+        self._is_dragging = False
         self.setBrush(QBrush(QColor("#28A745")))
         self.setPen(QPen(QColor("#FFFFFF"), 2))
         self.setZValue(1000)
@@ -102,6 +110,8 @@ class RotateHandle(QGraphicsEllipseItem):
 
     def mousePressEvent(self, event):
         """핸들 클릭 시 부모에게 회전 시작 알림"""
+        self._is_dragging = True
+        self.grabMouse()  # 마우스 캡처
         parent = self.parentItem()
         if parent and hasattr(parent, '_start_rotate_from_handle'):
             parent._start_rotate_from_handle(event)
@@ -109,6 +119,8 @@ class RotateHandle(QGraphicsEllipseItem):
 
     def mouseMoveEvent(self, event):
         """드래그 시 부모에게 전달"""
+        if not self._is_dragging:
+            return
         parent = self.parentItem()
         if parent and hasattr(parent, '_handle_rotate_from_handle'):
             parent._handle_rotate_from_handle(event)
@@ -116,6 +128,8 @@ class RotateHandle(QGraphicsEllipseItem):
 
     def mouseReleaseEvent(self, event):
         """릴리즈 시 부모에게 전달"""
+        self._is_dragging = False
+        self.ungrabMouse()  # 마우스 릴리즈
         parent = self.parentItem()
         if parent and hasattr(parent, '_end_rotate_from_handle'):
             parent._end_rotate_from_handle(event)
@@ -244,6 +258,8 @@ class BaseLayer(QGraphicsItem):
             self.is_rotating = True
             center = self.boundingRect().center()
             self.rotate_start_angle = self._calculate_angle(center, event.pos())
+            # 회전 중에는 드래그 비활성화
+            self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, False)
             event.accept()
             return
 
@@ -253,7 +269,10 @@ class BaseLayer(QGraphicsItem):
                 self.is_resizing = True
                 self.resize_handle_active = pos
                 self.resize_start_rect = self.boundingRect()
+                self._resize_start_item_pos = self.pos()  # 초기 위치 저장
                 self.resize_start_pos = event.pos()
+                # 리사이징 중에는 드래그 비활성화
+                self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, False)
                 event.accept()
                 return
 
@@ -284,6 +303,10 @@ class BaseLayer(QGraphicsItem):
             # 크기 조절 정리 (서브클래스에서 사용)
             self._cleanup_resize()
 
+            # 드래그 다시 활성화 (잠금 상태가 아닌 경우)
+            if not self.layer_locked:
+                self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, True)
+
             self.signals.transform_changed.emit()
             event.accept()
             return
@@ -295,6 +318,12 @@ class BaseLayer(QGraphicsItem):
         # 텍스트 레이어에서 사용하는 임시 속성 정리
         if hasattr(self, 'resize_start_font_size'):
             delattr(self, 'resize_start_font_size')
+        # 리사이즈 시작 위치 정리
+        if hasattr(self, '_resize_start_item_pos'):
+            delattr(self, '_resize_start_item_pos')
+        # 화면 좌표 정리
+        if hasattr(self, '_resize_start_screen_pos'):
+            delattr(self, '_resize_start_screen_pos')
 
     def _handle_rotation(self, pos):
         """회전 처리 - 서브클래스에서 구현 가능"""
@@ -316,18 +345,23 @@ class BaseLayer(QGraphicsItem):
         self.is_resizing = True
         self.resize_handle_active = position
         self.resize_start_rect = self.boundingRect()
-        # 핸들의 로컬 좌표를 부모(레이어) 좌표로 변환
-        self.resize_start_pos = self.resize_handles[position].mapToParent(event.pos())
+        self._resize_start_item_pos = self.pos()  # 초기 위치 저장
+        # 화면 절대 좌표 저장 (어떤 변환도 거치지 않음)
+        self._resize_start_screen_pos = event.screenPos()
+        # 리사이징 중에는 드래그 비활성화
+        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, False)
 
     def _handle_resize_from_handle(self, event):
         """핸들에서 리사이즈 처리"""
         if not self.is_resizing:
             return
-        # 핸들의 로컬 좌표를 부모(레이어) 좌표로 변환
-        handle = self.resize_handles.get(self.resize_handle_active)
-        if handle:
-            pos = handle.mapToParent(event.pos())
-            self._handle_resize(pos)
+        # 화면 절대 좌표로 delta 계산 (어떤 좌표 변환도 없음)
+        current_screen = event.screenPos()
+        dx = current_screen.x() - self._resize_start_screen_pos.x()
+        dy = current_screen.y() - self._resize_start_screen_pos.y()
+        from PySide6.QtCore import QPointF
+        delta = QPointF(dx, dy)
+        self._handle_resize_with_delta(delta)
 
     def _end_resize_from_handle(self, event):
         """핸들에서 리사이즈 종료"""
@@ -335,6 +369,9 @@ class BaseLayer(QGraphicsItem):
             self.is_resizing = False
             self.resize_handle_active = None
             self._cleanup_resize()
+            # 드래그 다시 활성화 (잠금 상태가 아닌 경우)
+            if not self.layer_locked:
+                self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, True)
             self.signals.transform_changed.emit()
 
     def _start_rotate_from_handle(self, event):
@@ -343,26 +380,35 @@ class BaseLayer(QGraphicsItem):
             return
         self.is_rotating = True
         center = self.boundingRect().center()
-        # 핸들의 로컬 좌표를 부모(레이어) 좌표로 변환
-        pos = self.rotate_handle.mapToParent(event.pos())
+        # scene 좌표를 레이어 로컬 좌표로 변환
+        pos = self.mapFromScene(event.scenePos())
         self.rotate_start_angle = self._calculate_angle(center, pos)
+        # 회전 중에는 드래그 비활성화
+        self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, False)
 
     def _handle_rotate_from_handle(self, event):
         """핸들에서 회전 처리"""
         if not self.is_rotating:
             return
-        # 핸들의 로컬 좌표를 부모(레이어) 좌표로 변환
-        pos = self.rotate_handle.mapToParent(event.pos())
+        # scene 좌표를 레이어 로컬 좌표로 변환
+        pos = self.mapFromScene(event.scenePos())
         self._handle_rotation(pos)
 
     def _end_rotate_from_handle(self, event):
         """핸들에서 회전 종료"""
         if self.is_rotating:
             self.is_rotating = False
+            # 드래그 다시 활성화 (잠금 상태가 아닌 경우)
+            if not self.layer_locked:
+                self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsMovable, True)
             self.signals.transform_changed.emit()
 
     def _handle_resize(self, pos):
         """크기 조절 처리 - 서브클래스에서 구현"""
+        pass
+
+    def _handle_resize_with_delta(self, delta):
+        """delta 기반 크기 조절 처리 - 서브클래스에서 구현"""
         pass
 
     def _calculate_angle(self, center, point):

--- a/canvas/layers/image_layer.py
+++ b/canvas/layers/image_layer.py
@@ -78,9 +78,15 @@ class ImageLayer(BaseLayer):
         if not self.resize_handle_active or not self.resize_start_rect:
             return
 
+        # 핸들에서 시작한 경우 _handle_resize_with_delta 사용
+        if hasattr(self, '_resize_start_screen_pos'):
+            return
+
         delta = pos - self.resize_start_pos
         new_width = self.resize_start_rect.width()
         new_height = self.resize_start_rect.height()
+        dx = 0  # x 위치 변화량
+        dy = 0  # y 위치 변화량
 
         handle = self.resize_handle_active
 
@@ -89,25 +95,97 @@ class ImageLayer(BaseLayer):
             new_width = max(50, self.resize_start_rect.width() + delta.x())
         elif 'l' in handle:  # 왼쪽 (tl, bl, l)
             new_width = max(50, self.resize_start_rect.width() - delta.x())
+            dx = delta.x()  # 왼쪽으로 드래그하면 위치도 이동
 
         if 'b' in handle:  # 하단 (bl, br, b)
             new_height = max(50, self.resize_start_rect.height() + delta.y())
         elif 't' in handle:  # 상단 (tl, tr, t)
             new_height = max(50, self.resize_start_rect.height() - delta.y())
+            dy = delta.y()  # 위로 드래그하면 위치도 이동
 
         # 비율 유지
         if self.keep_aspect_ratio:
             aspect_ratio = self.pixmap.width() / self.pixmap.height()
             if abs(new_width - self.resize_start_rect.width()) > abs(new_height - self.resize_start_rect.height()):
                 new_height = new_width / aspect_ratio
+                # 상단 핸들이면 높이 변화에 따라 dy 재계산
+                if 't' in handle:
+                    dy = self.resize_start_rect.height() - new_height
             else:
                 new_width = new_height * aspect_ratio
+                # 왼쪽 핸들이면 너비 변화에 따라 dx 재계산
+                if 'l' in handle:
+                    dx = self.resize_start_rect.width() - new_width
 
         # 크기가 실제로 변경된 경우에만 업데이트
         if abs(new_width - self.image_width) > 0.5 or abs(new_height - self.image_height) > 0.5:
             self.prepareGeometryChange()
             self.image_width = new_width
             self.image_height = new_height
+
+            # 좌측/상단 핸들인 경우 위치 이동
+            if dx != 0 or dy != 0:
+                if not hasattr(self, '_resize_start_item_pos'):
+                    self._resize_start_item_pos = self.pos()
+                self.setPos(self._resize_start_item_pos.x() + dx,
+                           self._resize_start_item_pos.y() + dy)
+
+            self._update_handle_positions()
+            self.update()
+
+    def _handle_resize_with_delta(self, delta):
+        """delta 기반 크기 조절 처리 (핸들에서 호출)"""
+        if not self.resize_handle_active or not self.resize_start_rect:
+            return
+
+        start_width = self.resize_start_rect.width()
+        start_height = self.resize_start_rect.height()
+        new_width = start_width
+        new_height = start_height
+
+        handle = self.resize_handle_active
+
+        # 각 핸들에 따른 크기 조정
+        if 'r' in handle:  # 오른쪽 (tr, br, r)
+            new_width = max(50, start_width + delta.x())
+        elif 'l' in handle:  # 왼쪽 (tl, bl, l)
+            new_width = max(50, start_width - delta.x())
+
+        if 'b' in handle:  # 하단 (bl, br, b)
+            new_height = max(50, start_height + delta.y())
+        elif 't' in handle:  # 상단 (tl, tr, t)
+            new_height = max(50, start_height - delta.y())
+
+        # 비율 유지 - 핸들 위치에 따라 기준 축 고정 (튀는 현상 방지)
+        if self.keep_aspect_ratio:
+            aspect_ratio = self.pixmap.width() / self.pixmap.height()
+
+            if handle in ['t', 'b']:
+                # 상/하 핸들: height 기준으로 width 계산
+                new_width = new_height * aspect_ratio
+            else:
+                # 그 외 (l, r, tl, tr, bl, br): width 기준으로 height 계산
+                new_height = new_width / aspect_ratio
+
+        # 실제 크기 변화량으로 위치 이동량 계산 (delta가 아닌 크기 변화 기준)
+        dx = 0
+        dy = 0
+        if 'l' in handle:
+            dx = start_width - new_width  # 크기가 줄면 dx > 0 (오른쪽으로 이동)
+        if 't' in handle:
+            dy = start_height - new_height  # 크기가 줄면 dy > 0 (아래로 이동)
+
+        # 크기가 실제로 변경된 경우에만 업데이트
+        if abs(new_width - self.image_width) > 0.5 or abs(new_height - self.image_height) > 0.5:
+            self.prepareGeometryChange()
+            self.image_width = new_width
+            self.image_height = new_height
+
+            # 좌측/상단 핸들인 경우 위치 이동
+            if dx != 0 or dy != 0:
+                self.setPos(self._resize_start_item_pos.x() + dx,
+                           self._resize_start_item_pos.y() + dy)
+
             self._update_handle_positions()
             self.update()
 
@@ -158,12 +236,8 @@ class ImageLayer(BaseLayer):
 
         # 상하 반전
         if self.flip_vertical_enabled:
-            if self.flip_horizontal_enabled:
-                transform.scale(1, -1)
-                transform.translate(0, -self.original_pixmap.height())
-            else:
-                transform.scale(1, -1)
-                transform.translate(0, -self.original_pixmap.height())
+            transform.scale(1, -1)
+            transform.translate(0, -self.original_pixmap.height())
 
         # 변환 적용
         self.pixmap = self.original_pixmap.transformed(transform, Qt.TransformationMode.SmoothTransformation)

--- a/canvas/layers/text_layer.py
+++ b/canvas/layers/text_layer.py
@@ -184,19 +184,60 @@ class TextLayer(BaseLayer):
         if not hasattr(self, 'resize_start_font_size'):
             self.resize_start_font_size = self.text_font.pointSize()
 
-        # 오른쪽 또는 하단 핸들로 크기 조절
-        scale_factor = 1.0
-        if 'r' in handle or 'b' in handle:
-            scale_factor = 1.0 + (delta.x() + delta.y()) / 200.0
-        elif 'l' in handle or 't' in handle:
-            scale_factor = 1.0 - (delta.x() + delta.y()) / 200.0
+        # 각 핸들의 "바깥쪽" 방향으로 드래그하면 커지도록 계산
+        # br: +x, +y → 커짐 / bl: -x, +y → 커짐 / tr: +x, -y → 커짐 / tl: -x, -y → 커짐
+        outward_x = 0
+        outward_y = 0
+        if 'r' in handle:
+            outward_x = delta.x()
+        elif 'l' in handle:
+            outward_x = -delta.x()
+        if 'b' in handle:
+            outward_y = delta.y()
+        elif 't' in handle:
+            outward_y = -delta.y()
+
+        scale_factor = 1.0 + (outward_x + outward_y) / 200.0
 
         # 폰트 크기 변경 (시작 크기 기준으로 계산하여 부드럽게)
         new_size = max(8, min(200, int(self.resize_start_font_size * scale_factor)))
         current_size = self.text_font.pointSize()
 
         if new_size != current_size:
+            # 변경 전 바운딩 박스와 앵커 포인트 계산
+            old_rect = self.boundingRect()
+
+            # 각 핸들의 반대쪽(고정될 곳) 좌표 저장
+            if 'l' in handle and 't' in handle:  # tl → 우하단 고정
+                anchor = old_rect.bottomRight()
+            elif 'r' in handle and 't' in handle:  # tr → 좌하단 고정
+                anchor = old_rect.bottomLeft()
+            elif 'l' in handle and 'b' in handle:  # bl → 우상단 고정
+                anchor = old_rect.topRight()
+            else:  # br → 좌상단 고정
+                anchor = old_rect.topLeft()
+
+            # 폰트 크기 변경
             self.set_font_size(new_size)
+
+            # 변경 후 바운딩 박스
+            new_rect = self.boundingRect()
+
+            # 새로운 앵커 위치 계산
+            if 'l' in handle and 't' in handle:
+                new_anchor = new_rect.bottomRight()
+            elif 'r' in handle and 't' in handle:
+                new_anchor = new_rect.bottomLeft()
+            elif 'l' in handle and 'b' in handle:
+                new_anchor = new_rect.topRight()
+            else:
+                new_anchor = new_rect.topLeft()
+
+            # 앵커가 제자리에 있도록 위치 보정
+            dx = anchor.x() - new_anchor.x()
+            dy = anchor.y() - new_anchor.y()
+            if dx != 0 or dy != 0:
+                self.setPos(self.pos().x() + dx, self.pos().y() + dy)
 
     def get_layer_data(self):
         """레이어 데이터"""

--- a/canvas/layers/text_layer.py
+++ b/canvas/layers/text_layer.py
@@ -162,7 +162,22 @@ class TextLayer(BaseLayer):
         if not self.resize_handle_active or not self.resize_start_rect:
             return
 
+        # 핸들에서 시작한 경우 _handle_resize_with_delta 사용
+        if hasattr(self, '_resize_start_screen_pos'):
+            return
+
         delta = pos - self.resize_start_pos
+        self._apply_font_resize(delta)
+
+    def _handle_resize_with_delta(self, delta):
+        """delta 기반 크기 조절 처리 (핸들에서 호출)"""
+        if not self.resize_handle_active or not self.resize_start_rect:
+            return
+
+        self._apply_font_resize(delta)
+
+    def _apply_font_resize(self, delta):
+        """실제 폰트 크기 조절 로직"""
         handle = self.resize_handle_active
 
         # 초기 폰트 크기 저장 (처음 한 번만)

--- a/canvas/layers/text_layer.py
+++ b/canvas/layers/text_layer.py
@@ -112,6 +112,7 @@ class TextLayer(BaseLayer):
         self._update_bounding_rect()
         self._update_handle_positions()
         self.update()
+        self.signals.transform_changed.emit()
 
     def get_font_size(self):
         """폰트 크기 반환"""

--- a/ui_v2/panels/property_panel.py
+++ b/ui_v2/panels/property_panel.py
@@ -279,6 +279,15 @@ class PropertyPanel(QWidget):
 
     def set_layer(self, layer):
         """선택된 레이어 설정"""
+        # 이전 레이어 시그널 연결 해제
+        if self.current_layer is not None:
+            try:
+                self.current_layer.signals.transform_changed.disconnect(
+                    self._on_layer_transform_changed
+                )
+            except (RuntimeError, TypeError):
+                pass  # 연결 안 되어 있거나 이미 해제됨
+
         self.current_layer = layer
 
         if layer is None:
@@ -319,6 +328,9 @@ class PropertyPanel(QWidget):
             self.aspect_ratio_check.setChecked(layer.keep_aspect_ratio)
             self.aspect_ratio_check.blockSignals(False)
 
+            # 레이어 변형 시 속성 패널 갱신
+            layer.signals.transform_changed.connect(self._on_layer_transform_changed)
+
         # 텍스트 레이어인 경우
         elif isinstance(layer, TextLayer):
             self.text_group.setVisible(True)
@@ -346,9 +358,40 @@ class PropertyPanel(QWidget):
             self.underline_check.blockSignals(True)
             self.underline_check.setChecked(layer.get_underline())
             self.underline_check.blockSignals(False)
+
+            # 레이어 변형 시 속성 패널 갱신
+            layer.signals.transform_changed.connect(self._on_layer_transform_changed)
         else:
             self.text_group.setVisible(False)
             self.image_group.setVisible(False)
+
+    def _on_layer_transform_changed(self):
+        """레이어 변형 시 속성 패널 갱신"""
+        if not self.current_layer:
+            return
+
+        # 위치 갱신
+        self.x_spinbox.blockSignals(True)
+        self.y_spinbox.blockSignals(True)
+        self.x_spinbox.setValue(self.current_layer.pos().x())
+        self.y_spinbox.setValue(self.current_layer.pos().y())
+        self.x_spinbox.blockSignals(False)
+        self.y_spinbox.blockSignals(False)
+
+        # 텍스트 레이어인 경우 폰트 크기 등 갱신
+        from canvas.layers import TextLayer
+        if isinstance(self.current_layer, TextLayer):
+            self.font_size_spinbox.blockSignals(True)
+            self.font_size_spinbox.setValue(self.current_layer.get_font_size())
+            self.font_size_spinbox.blockSignals(False)
+
+            self.bold_check.blockSignals(True)
+            self.bold_check.setChecked(self.current_layer.get_bold())
+            self.bold_check.blockSignals(False)
+
+            self.italic_check.blockSignals(True)
+            self.italic_check.setChecked(self.current_layer.get_italic())
+            self.italic_check.blockSignals(False)
 
     def _on_position_changed(self):
         """위치 변경"""


### PR DESCRIPTION
  ## Summary
  이미지 레이어 리사이즈 핸들의 클릭 판정, 드래그 동작, 방향 처리를 전면 개선했습니다.

  ## Changes

  ### 핸들 클릭 판정 개선
  - `a5f0462` fix: 이미지 리사이즈/회전 핸들 클릭 판정 개선
    - 핸들 클릭 판정 영역 확장 (8x8 → 20x20px)
    - 핸들이 직접 마우스 이벤트를 받아 부모에게 전달
    - 이미지 바운딩 박스 밖에서도 핸들 조작 가능

  ### ImageLayer 리사이즈 개선
  - `fa8b60e` fix: 이미지 리사이즈 핸들 개선 및 코드 정리
    - screenPos() 사용으로 모니터화면 절대좌표로 계산 
    - grabMouse() 추가로 핸들 드래그 중 마우스 캡처
    - ItemIsMovable 플래그 관리로 리사이즈/드래그 충돌 방지
    - 핸들 드래그 시 반대편 고정 유지 (예: 좌상단 핸들 움직일때 우하단 핸들 위치 고정)
    - 비율 고정 시 핸들 위치 기반 가로/세로 축 고정으로 튀는 현상 방지

  ### TextLayer 리사이즈 지원
  - `e3f632d` fix: TextLayer 핸들 리사이즈 지원 추가
    - _handle_resize_with_delta 메서드 추가
    - 공통 로직을 _apply_font_resize로 분리

  - `a83d6ed` fix: TextLayer 리사이즈 방향 및 앵커 포인트 수정
    - 각 핸들의 바깥 방향으로 드래그 시 크기 증가
    - 모든 핸들에 대해 반대쪽 앵커 포인트 (반대쪽 핸들 좌표) 고정
    - QFontMetrics 바운딩 박스 원점 이동 보정

  ### 속성 패널 실시간 갱신
  - `7fc2d53` feat: 레이어 변형 시 속성 패널 실시간 갱신
    - PropertyPanel에 transform_changed 시그널 연결
    - 리사이즈 중 위치, 폰트 크기 등 속성값 실시간 갱신